### PR TITLE
add custom word lists

### DIFF
--- a/.changeset/custom-word-lists.md
+++ b/.changeset/custom-word-lists.md
@@ -1,0 +1,5 @@
+---
+"joyful": minor
+---
+
+Add custom word lists and exact-word omission support to the API and CLI. Permutation counts now reflect unique generatable names when custom lists overlap.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [haydenbleasel]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ import { joyful } from "joyful";
 joyful(); // "amber-fox"
 joyful({ segments: 3 }); // "golden-marble-cathedral"
 joyful({ separator: "_" }); // "swift_otter"
+joyful({ omit: ["fox"] }); // excludes "fox" from generated names
 ```
 
 You can also use the CLI:
@@ -28,6 +29,7 @@ You can also use the CLI:
 joyful
 joyful --segments 3
 joyful --pattern color,nature,animal
+joyful --omit fox,wolf
 ```
 
 ## Generate Names
@@ -63,6 +65,33 @@ Pattern rules:
 - `separator` and `maxLength` still apply to generated names.
 - Unknown categories throw an error with the supported category names.
 
+## Custom Word Lists
+
+Use `wordLists` to add named word pools that can be selected by `pattern`.
+Use `omit` to exclude exact words from both built-in and custom lists.
+
+```ts
+joyful({
+  pattern: ["fruit", "texture"],
+  wordLists: {
+    fruit: ["apple", "pear"],
+    texture: ["linen", "silk"],
+  },
+}); // "pear-linen"
+
+joyful({
+  omit: ["pear", "silk"],
+  pattern: ["fruit", "texture"],
+  wordLists: {
+    fruit: ["apple", "pear"],
+    texture: ["linen", "silk"],
+  },
+}); // "apple-linen"
+```
+
+Custom category names are additive. If a custom list uses a built-in category
+name, such as `animal`, it replaces that built-in category for the current call.
+
 ## CLI
 
 The CLI supports the same core generation options:
@@ -74,6 +103,8 @@ joyful --separator _
 joyful --max-length 12
 joyful --pattern adjective,animal
 joyful --pattern city,nature,space --separator _
+joyful --word-list fruit=apple,pear --word-list texture=linen,silk --pattern fruit,texture
+joyful --omit fox,wolf
 ```
 
 Short flags are available for common generation options:
@@ -93,9 +124,17 @@ Use `permutations()` to count possible unbounded combinations without generating
 import { permutations } from "joyful";
 
 permutations(); // 997425
-permutations({ segments: 3 }); // 2917468125
+permutations({ segments: 3 }); // 2916470700
 permutations({ pattern: ["adjective", "animal"] }); // 46081
 permutations({ pattern: ["color", "nature", "animal"] }); // 4674684
+permutations({
+  omit: ["pear"],
+  pattern: ["fruit", "texture"],
+  wordLists: {
+    fruit: ["apple", "pear"],
+    texture: ["linen", "silk"],
+  },
+}); // 2
 ```
 
 The CLI can print the same counts:
@@ -104,6 +143,7 @@ The CLI can print the same counts:
 joyful --permutations
 joyful --permutations --segments 3
 joyful --permutations --pattern color,nature,animal
+joyful --permutations --word-list fruit=apple,pear --pattern fruit,animal
 ```
 
 For automation, add `--json`:
@@ -119,7 +159,7 @@ joyful --permutations --pattern color,nature,animal --json
 }
 ```
 
-Permutation counts do not account for `maxLength`, because bounded generation depends on word lengths and fitting constraints.
+Permutation counts include only unique names that can be generated without repeated words. They do not account for `maxLength`, because bounded generation depends on word lengths and fitting constraints.
 
 ## API
 
@@ -127,21 +167,25 @@ Permutation counts do not account for `maxLength`, because bounded generation de
 
 Returns a generated name as a `string`.
 
-| Option      | Type               | Default | Description                           |
-| ----------- | ------------------ | ------- | ------------------------------------- |
-| `segments`  | `number`           | `2`     | Number of words to generate           |
-| `pattern`   | `JoyfulCategory[]` | none    | Category pattern for each word        |
-| `separator` | `string`           | `"-"`   | Character(s) between words            |
-| `maxLength` | `number`           | none    | Maximum length of the returned string |
+| Option      | Type                                    | Default | Description                           |
+| ----------- | --------------------------------------- | ------- | ------------------------------------- |
+| `segments`  | `number`                                | `2`     | Number of words to generate           |
+| `pattern`   | `JoyfulCategory[]` or custom `string[]` | none    | Category pattern for each word        |
+| `wordLists` | `Record<string, readonly string[]>`     | none    | Custom named word lists               |
+| `omit`      | `readonly string[]`                     | none    | Exact words to exclude                |
+| `separator` | `string`                                | `"-"`   | Character(s) between words            |
+| `maxLength` | `number`                                | none    | Maximum length of the returned string |
 
 ### `permutations(options?)`
 
 Returns the number of possible unbounded combinations as a `number`.
 
-| Option     | Type               | Default | Description                    |
-| ---------- | ------------------ | ------- | ------------------------------ |
-| `segments` | `number`           | `2`     | Number of words to count       |
-| `pattern`  | `JoyfulCategory[]` | none    | Category pattern for each word |
+| Option      | Type                                    | Default | Description                    |
+| ----------- | --------------------------------------- | ------- | ------------------------------ |
+| `segments`  | `number`                                | `2`     | Number of words to count       |
+| `pattern`   | `JoyfulCategory[]` or custom `string[]` | none    | Category pattern for each word |
+| `wordLists` | `Record<string, readonly string[]>`     | none    | Custom named word lists        |
+| `omit`      | `readonly string[]`                     | none    | Exact words to exclude         |
 
 ### `JoyfulCategory`
 
@@ -203,9 +247,9 @@ Default generation starts with an adjective or color, then draws each later word
 | Segments | Combinations           |
 | -------- | ---------------------- |
 | 2        | 997,425                |
-| 3        | 2,917,468,125          |
-| 4        | 8,533,594,265,625      |
-| 5        | 24,960,763,226,953,124 |
+| 3        | 2,916,470,700          |
+| 4        | 8,524,843,856,100      |
+| 5        | 24,909,593,747,524,200 |
 
 ## Errors And Constraints
 
@@ -213,6 +257,7 @@ Default generation starts with an adjective or color, then draws each later word
 - `separator` cannot be an empty string.
 - `maxLength` must be a positive integer when provided.
 - Unknown pattern categories throw an error.
+- Custom word list names cannot be empty.
 - CLI `--json` is only supported with `--permutations`.
 - CLI `--permutations` does not support `--max-length`.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -86,6 +86,59 @@ describe("cli", () => {
     });
   });
 
+  describe("--word-list and --omit flags", () => {
+    it("generates words from custom CLI word lists", async () => {
+      const { stdout, exitCode } = await run([
+        "--word-list",
+        "fruit=apple",
+        "--word-list",
+        "texture=linen",
+        "--pattern",
+        "fruit,texture",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe("apple-linen");
+    });
+
+    it("omits words from custom CLI word lists", async () => {
+      const { stdout, exitCode } = await run([
+        "--word-list",
+        "fruit=apple,pear",
+        "--word-list",
+        "texture=linen,silk",
+        "--omit",
+        "pear,silk",
+        "--pattern",
+        "fruit,texture",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe("apple-linen");
+    });
+
+    it("supports custom list permutations as JSON", async () => {
+      const { stdout, exitCode } = await run([
+        "--permutations",
+        "--json",
+        "--word-list",
+        "fruit=apple,pear",
+        "--word-list",
+        "texture=linen,silk,velvet",
+        "--omit",
+        "pear",
+        "--pattern",
+        "fruit,texture",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout)).toEqual({
+        pattern: ["fruit", "texture"],
+        permutations: 3,
+      });
+    });
+  });
+
   describe("--separator flag", () => {
     it("uses underscore with --separator _", async () => {
       const { stdout, exitCode } = await run(["--separator", "_"]);
@@ -152,7 +205,7 @@ describe("cli", () => {
       ]);
 
       expect(exitCode).toBe(0);
-      expect(stdout).toBe("3 words: 2,917,468,125");
+      expect(stdout).toBe("3 words: 2,916,470,700");
     });
 
     it("prints a single segment count as JSON", async () => {
@@ -165,7 +218,7 @@ describe("cli", () => {
 
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
-        permutations: 2_917_468_125,
+        permutations: 2_916_470_700,
         segments: 3,
       });
     });
@@ -247,6 +300,20 @@ describe("cli", () => {
       const { stderr, exitCode } = await run(["--pattern", "adjective,planet"]);
       expect(exitCode).toBe(1);
       expect(stderr).toContain('Unknown pattern category "planet"');
+    });
+
+    it("exits with code 1 for invalid custom word list syntax", async () => {
+      const { stderr, exitCode } = await run(["--word-list", "fruit"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain(
+        '--word-list must use the format "name=word,word"'
+      );
+    });
+
+    it("exits with code 1 when a flag value is missing", async () => {
+      const { stderr, exitCode } = await run(["--omit", "--pattern", "animal"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("--omit requires a value");
     });
 
     it("exits with code 1 for json without permutations", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,65 +1,135 @@
 #!/usr/bin/env node
 
 import { joyful, permutations } from "./index";
-import type { JoyfulCategory, JoyfulOptions } from "./index";
+import type {
+  JoyfulCategory,
+  JoyfulOptions,
+  JoyfulWordLists,
+  PermutationsOptions,
+} from "./index";
 
 const args = process.argv.slice(2);
+const knownFlags = new Set([
+  "--help",
+  "-h",
+  "--json",
+  "--max-length",
+  "-m",
+  "--omit",
+  "-o",
+  "--pattern",
+  "-t",
+  "--permutations",
+  "--segments",
+  "-s",
+  "--separator",
+  "-p",
+  "--word-list",
+  "-w",
+]);
+
+const getFlagValue = (index: number, name: string): string => {
+  const value = args[index + 1];
+
+  if (value === undefined || knownFlags.has(value)) {
+    throw new Error(`--${name} requires a value`);
+  }
+
+  return value;
+};
 
 const parseFlag = (name: string, short: string): string | undefined => {
   for (let i = 0; i < args.length; i += 1) {
     if (args[i] === `--${name}` || args[i] === `-${short}`) {
-      return args[i + 1];
+      return getFlagValue(i, name);
     }
   }
   return undefined;
+};
+
+const parseFlags = (name: string, short: string): string[] => {
+  const values: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === `--${name}` || args[i] === `-${short}`) {
+      values.push(getFlagValue(i, name));
+    }
+  }
+
+  return values;
 };
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`Usage: joyful [options]
 
 Options:
-  -s, --segments <number>    Number of words to generate (default: 2)
-  -t, --pattern <categories> Category pattern, comma-separated
-  -p, --separator <string>   Separator between words (default: "-")
-  -m, --max-length <number>  Maximum length of the result
-      --permutations         Calculate possible permutations
-      --json                 Output permutation results as JSON
-  -h, --help                 Show this help message`);
+  -s, --segments <number>       Number of words to generate (default: 2)
+  -t, --pattern <categories>    Category pattern, comma-separated
+  -w, --word-list <name=words>  Custom list, comma-separated; repeatable
+  -o, --omit <words>            Words to omit, comma-separated; repeatable
+  -p, --separator <string>      Separator between words (default: "-")
+  -m, --max-length <number>     Maximum length of the result
+      --permutations            Calculate possible permutations
+      --json                    Output permutation results as JSON
+  -h, --help                    Show this help message`);
   process.exit(0);
 }
 
 const hasFlag = (name: string): boolean => args.includes(`--${name}`);
 
-const segmentsRaw = parseFlag("segments", "s");
-const patternRaw = parseFlag("pattern", "t");
-const separator = parseFlag("separator", "p");
-const maxLengthRaw = parseFlag("max-length", "m");
+let segmentsRaw: string | undefined;
+let patternRaw: string | undefined;
+let wordListRaw: string[] = [];
+let omitRaw: string[] = [];
+let maxLengthRaw: string | undefined;
 const shouldCalculatePermutations = hasFlag("permutations");
 const shouldOutputJson = hasFlag("json");
 
-const parsePattern = (value: string): JoyfulCategory[] =>
+const parseCommaSeparated = (value: string): string[] =>
   value
     .split(",")
-    .map((category) => category.trim())
-    .filter(Boolean) as JoyfulCategory[];
+    .map((item) => item.trim())
+    .filter(Boolean);
 
-const options: JoyfulOptions = {};
+const parsePattern = (value: string): string[] => parseCommaSeparated(value);
 
-if (segmentsRaw !== undefined) {
-  options.segments = Number.parseInt(segmentsRaw, 10);
+const parseWordLists = (values: string[]): JoyfulWordLists | undefined => {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const wordLists: JoyfulWordLists = {};
+
+  for (const value of values) {
+    const separatorIndex = value.indexOf("=");
+
+    if (separatorIndex <= 0) {
+      throw new Error('--word-list must use the format "name=word,word"');
+    }
+
+    const name = value.slice(0, separatorIndex).trim();
+    const words = parseCommaSeparated(value.slice(separatorIndex + 1));
+
+    if (words.length === 0) {
+      throw new Error(`Custom word list "${name}" must include words`);
+    }
+
+    wordLists[name] = [...(wordLists[name] ?? []), ...words];
+  }
+
+  return wordLists;
+};
+
+interface CliOptions {
+  maxLength?: number;
+  omit?: string[];
+  pattern?: string[];
+  segments?: number;
+  separator?: string;
+  wordLists?: JoyfulWordLists;
 }
 
-if (patternRaw !== undefined) {
-  options.pattern = parsePattern(patternRaw);
-}
-
-if (separator !== undefined) {
-  options.separator = separator;
-}
-
-if (maxLengthRaw !== undefined) {
-  options.maxLength = Number.parseInt(maxLengthRaw, 10);
-}
+const options: CliOptions = {};
 
 const commonPatterns = [
   ["adjective", "animal"],
@@ -81,16 +151,28 @@ const printJson = (value: unknown): void => {
   console.log(JSON.stringify(value, null, 2));
 };
 
+const getPermutationOptions = (
+  overrides: { pattern?: readonly string[]; segments?: number } = {}
+): PermutationsOptions =>
+  ({
+    omit: options.omit,
+    pattern: overrides.pattern,
+    segments: overrides.segments,
+    wordLists: options.wordLists,
+  }) as PermutationsOptions;
+
 const getSegmentResults = (): SegmentPermutation[] =>
   [2, 3, 4, 5].map((segmentCount) => ({
-    permutations: permutations({ segments: segmentCount }),
+    permutations: permutations(
+      getPermutationOptions({ segments: segmentCount })
+    ),
     segments: segmentCount,
   }));
 
 const getPatternResults = (): PatternPermutation[] =>
   commonPatterns.map((pattern) => ({
     pattern,
-    permutations: permutations({ pattern }),
+    permutations: permutations(getPermutationOptions({ pattern })),
   }));
 
 const printSegmentResults = (segments: SegmentPermutation[]): void => {
@@ -124,8 +206,11 @@ const printPermutationSummary = (): void => {
   printPatternResults(patterns);
 };
 
-const printPatternPermutation = (pattern: readonly JoyfulCategory[]): void => {
-  const result = { pattern, permutations: permutations({ pattern }) };
+const printPatternPermutation = (pattern: readonly string[]): void => {
+  const result = {
+    pattern,
+    permutations: permutations(getPermutationOptions({ pattern })),
+  };
 
   if (shouldOutputJson) {
     printJson(result);
@@ -138,7 +223,10 @@ const printPatternPermutation = (pattern: readonly JoyfulCategory[]): void => {
 };
 
 const printSegmentPermutation = (segments: number): void => {
-  const result = { permutations: permutations({ segments }), segments };
+  const result = {
+    permutations: permutations(getPermutationOptions({ segments })),
+    segments,
+  };
 
   if (shouldOutputJson) {
     printJson(result);
@@ -169,6 +257,40 @@ const printPermutationResult = (): void => {
 };
 
 try {
+  segmentsRaw = parseFlag("segments", "s");
+  patternRaw = parseFlag("pattern", "t");
+  wordListRaw = parseFlags("word-list", "w");
+  omitRaw = parseFlags("omit", "o");
+  maxLengthRaw = parseFlag("max-length", "m");
+
+  const separator = parseFlag("separator", "p");
+
+  if (segmentsRaw !== undefined) {
+    options.segments = Number.parseInt(segmentsRaw, 10);
+  }
+
+  if (patternRaw !== undefined) {
+    options.pattern = parsePattern(patternRaw);
+  }
+
+  if (separator !== undefined) {
+    options.separator = separator;
+  }
+
+  if (maxLengthRaw !== undefined) {
+    options.maxLength = Number.parseInt(maxLengthRaw, 10);
+  }
+
+  const parsedWordLists = parseWordLists(wordListRaw);
+
+  if (parsedWordLists) {
+    options.wordLists = parsedWordLists;
+  }
+
+  if (omitRaw.length > 0) {
+    options.omit = omitRaw.flatMap(parseCommaSeparated);
+  }
+
   if (shouldOutputJson && !shouldCalculatePermutations) {
     throw new Error("--json is only supported with --permutations");
   }
@@ -178,7 +300,7 @@ try {
     process.exit(0);
   }
 
-  console.log(joyful(options));
+  console.log(joyful(options as JoyfulOptions));
 } catch (error) {
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -207,13 +207,104 @@ describe("joyful", () => {
     });
   });
 
+  describe("custom word lists", () => {
+    it("generates words from custom pattern categories", () => {
+      const result = joyful({
+        pattern: ["fruit", "texture"],
+        wordLists: {
+          fruit: ["apple"],
+          texture: ["linen"],
+        },
+      });
+
+      expect(result).toBe("apple-linen");
+    });
+
+    it("omits words from custom lists", () => {
+      const result = joyful({
+        omit: ["pear", "silk"],
+        pattern: ["fruit", "texture"],
+        wordLists: {
+          fruit: ["apple", "pear"],
+          texture: ["silk", "linen"],
+        },
+      });
+
+      expect(result).toBe("apple-linen");
+    });
+
+    it("omits words from built-in pattern categories", () => {
+      const [remainingAnimal] = animals;
+      const result = joyful({
+        omit: animals.filter((word) => word !== remainingAnimal),
+        pattern: ["animal", "fruit"],
+        wordLists: {
+          fruit: ["apple"],
+        },
+      });
+
+      expect(result).toBe(`${remainingAnimal}-apple`);
+    });
+
+    it("supports custom lists with maxLength", () => {
+      const result = joyful({
+        maxLength: 11,
+        pattern: ["fruit", "texture"],
+        wordLists: {
+          fruit: ["apple", "pomegranate"],
+          texture: ["linen"],
+        },
+      });
+
+      expect(result).toBe("apple-linen");
+    });
+
+    it("chooses a bounded pattern word that leaves overlapping lists possible", () => {
+      const result = joyful({
+        maxLength: 12,
+        pattern: ["first", "second"],
+        wordLists: {
+          first: ["shared", "alpha"],
+          second: ["shared"],
+        },
+      });
+
+      expect(result).toBe("alpha-shared");
+    });
+
+    it("chooses a pattern word that leaves overlapping lists possible", () => {
+      const result = joyful({
+        pattern: ["first", "second"],
+        wordLists: {
+          first: ["shared", "alpha"],
+          second: ["shared"],
+        },
+      });
+
+      expect(result).toBe("alpha-shared");
+    });
+
+    it("throws when omitted words leave a pattern category empty", () => {
+      expect(() =>
+        joyful({
+          omit: ["apple"],
+          pattern: ["fruit", "texture"],
+          wordLists: {
+            fruit: ["apple"],
+            texture: ["linen"],
+          },
+        })
+      ).toThrow('Not enough unique words in pattern category "fruit"');
+    });
+  });
+
   describe("permutations", () => {
     it("returns the default 2-word count", () => {
       expect(permutations()).toBe(997_425);
     });
 
     it("returns the default 3-word count", () => {
-      expect(permutations({ segments: 3 })).toBe(2_917_468_125);
+      expect(permutations({ segments: 3 })).toBe(2_916_470_700);
     });
 
     it("counts adjective and animal patterns", () => {
@@ -224,6 +315,72 @@ describe("joyful", () => {
       expect(permutations({ pattern: ["color", "nature", "animal"] })).toBe(
         4_674_684
       );
+    });
+
+    it("counts custom pattern categories", () => {
+      expect(
+        permutations({
+          pattern: ["fruit", "texture"],
+          wordLists: {
+            fruit: ["apple", "pear"],
+            texture: ["linen", "silk", "velvet"],
+          },
+        })
+      ).toBe(6);
+    });
+
+    it("counts omitted words", () => {
+      expect(
+        permutations({
+          omit: ["pear", "silk"],
+          pattern: ["fruit", "texture"],
+          wordLists: {
+            fruit: ["apple", "pear"],
+            texture: ["linen", "silk", "velvet"],
+          },
+        })
+      ).toBe(2);
+    });
+
+    it("does not double-count duplicate custom prefixes", () => {
+      const duplicatePrefixCount = permutations({
+        wordLists: {
+          adjective: ["bright"],
+          color: ["bright"],
+        },
+      });
+      const singlePrefixCount = permutations({
+        wordLists: {
+          adjective: ["bright"],
+          color: [],
+        },
+      });
+
+      expect(duplicatePrefixCount).toBe(singlePrefixCount);
+    });
+
+    it("counts only unique generatable custom pattern permutations", () => {
+      expect(
+        permutations({
+          pattern: ["first", "second"],
+          wordLists: {
+            first: ["shared", "alpha"],
+            second: ["shared"],
+          },
+        })
+      ).toBe(1);
+    });
+
+    it("does not count impossible duplicate-only pattern permutations", () => {
+      expect(
+        permutations({
+          pattern: ["first", "second"],
+          wordLists: {
+            first: ["apple"],
+            second: ["apple"],
+          },
+        })
+      ).toBe(0);
     });
 
     it("throws for unknown pattern categories", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,21 +18,60 @@ import space from "./lib/space.json" with { type: "json" };
 import sports from "./lib/sports.json" with { type: "json" };
 import transportation from "./lib/transportation.json" with { type: "json" };
 
-export interface JoyfulOptions {
+export type JoyfulWordLists = Record<string, readonly string[]>;
+
+interface BaseJoyfulOptions {
   maxLength?: number;
-  pattern?: readonly JoyfulCategory[];
+  omit?: readonly string[];
   segments?: number;
   separator?: string;
 }
 
-export interface PermutationsOptions {
-  pattern?: readonly JoyfulCategory[];
-  segments?: number;
+export type JoyfulOptions =
+  | (BaseJoyfulOptions & {
+      pattern?: readonly JoyfulCategory[];
+      wordLists?: undefined;
+    })
+  | (BaseJoyfulOptions & {
+      pattern?: readonly string[];
+      wordLists: JoyfulWordLists;
+    });
+
+export type PermutationsOptions =
+  | {
+      omit?: readonly string[];
+      pattern?: readonly JoyfulCategory[];
+      segments?: number;
+      wordLists?: undefined;
+    }
+  | {
+      omit?: readonly string[];
+      pattern?: readonly string[];
+      segments?: number;
+      wordLists: JoyfulWordLists;
+    };
+
+interface ActiveWordLists {
+  categoryNames: string[];
+  categoryWordLists: Record<string, string[]>;
+  categoryWords: string[];
+  prefixes: string[];
 }
 
-const MIN_CATEGORY_WORD_LENGTH = 2;
+interface DefaultWordPools {
+  categoryWords: string[];
+  prefixes: string[];
+}
 
-const prefixes = [...adjectives, ...colors];
+interface GenerationOptions {
+  categoryWordLists: Record<string, string[]>;
+  categoryWords: string[];
+  prefixes: string[];
+}
+
+interface ResolvedOptions extends GenerationOptions {
+  categoryNames: string[];
+}
 
 const categoryWordLists = {
   adjective: adjectives,
@@ -60,9 +99,6 @@ export type JoyfulCategory = keyof typeof categoryWordLists;
 
 const categoryNames = Object.keys(categoryWordLists) as JoyfulCategory[];
 
-const isJoyfulCategory = (category: string): category is JoyfulCategory =>
-  Object.hasOwn(categoryWordLists, category);
-
 const categories = [
   animals,
   architecture,
@@ -84,20 +120,90 @@ const categories = [
 ];
 
 const categoryWords = categories.flat();
-const defaultCategoryWordCount = categoryWords.length;
+const prefixes = [...adjectives, ...colors];
+const defaultWordLists: ActiveWordLists = {
+  categoryNames,
+  categoryWordLists,
+  categoryWords,
+  prefixes,
+};
 
 const getRandomElement = <T>(array: T[]): T =>
   array[Math.floor(Math.random() * array.length)];
 
-const validatePattern = (pattern?: readonly JoyfulCategory[]): void => {
+const isStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((word) => typeof word === "string");
+
+const uniqueWords = (words: readonly string[]): string[] => [...new Set(words)];
+
+const validateWordLists = (wordLists?: JoyfulWordLists): void => {
+  if (!wordLists) {
+    return;
+  }
+
+  for (const [name, words] of Object.entries(wordLists)) {
+    if (!name) {
+      throw new Error("Custom word list names cannot be empty");
+    }
+
+    if (!isStringArray(words)) {
+      throw new Error(`Custom word list "${name}" must contain strings`);
+    }
+  }
+};
+
+const filterWords = (
+  words: readonly string[],
+  omittedWords: ReadonlySet<string>
+): string[] => uniqueWords(words).filter((word) => !omittedWords.has(word));
+
+const getActiveWordLists = (
+  wordLists?: JoyfulWordLists,
+  omit: readonly string[] = []
+): ActiveWordLists => {
+  validateWordLists(wordLists);
+
+  if (!wordLists && omit.length === 0) {
+    return defaultWordLists;
+  }
+
+  const omittedWords = new Set(omit);
+  const mergedWordLists = { ...categoryWordLists, ...wordLists };
+  const activeCategoryWordLists: Record<string, string[]> = {};
+
+  for (const [name, words] of Object.entries(mergedWordLists)) {
+    activeCategoryWordLists[name] = filterWords(words, omittedWords);
+  }
+
+  const activeCategoryNames = Object.keys(activeCategoryWordLists);
+  const activeCategories = Object.entries(activeCategoryWordLists)
+    .filter(([name]) => name !== "adjective" && name !== "color")
+    .map(([, words]) => words);
+
+  return {
+    categoryNames: activeCategoryNames,
+    categoryWordLists: activeCategoryWordLists,
+    categoryWords: uniqueWords(activeCategories.flat()),
+    prefixes: uniqueWords([
+      ...(activeCategoryWordLists.adjective ?? []),
+      ...(activeCategoryWordLists.color ?? []),
+    ]),
+  };
+};
+
+const validatePattern = (
+  availableCategoryNames: readonly string[],
+  availableWordLists: Record<string, string[]>,
+  pattern?: readonly string[]
+): void => {
   if (!pattern) {
     return;
   }
 
   for (const category of pattern) {
-    if (!isJoyfulCategory(category)) {
+    if (!Object.hasOwn(availableWordLists, category)) {
       throw new Error(
-        `Unknown pattern category "${category}". Expected one of: ${categoryNames.join(
+        `Unknown pattern category "${category}". Expected one of: ${availableCategoryNames.join(
           ", "
         )}`
       );
@@ -115,7 +221,8 @@ const validateInput = (
   segments: number,
   separator: string,
   maxLength?: number,
-  pattern?: readonly JoyfulCategory[]
+  pattern?: readonly string[],
+  resolvedOptions: ResolvedOptions = defaultWordLists
 ): void => {
   const wordCount = pattern?.length ?? segments;
 
@@ -132,47 +239,120 @@ const validateInput = (
     throw new Error("maxLength must be a positive integer");
   }
 
-  validatePattern(pattern);
+  validatePattern(
+    resolvedOptions.categoryNames,
+    resolvedOptions.categoryWordLists,
+    pattern
+  );
 };
 
-const getDefaultPermutations = (segments: number): number => {
-  validateWordCount(segments);
-
-  let total = prefixes.length;
-
-  for (let index = 1; index < segments; index += 1) {
-    total *= defaultCategoryWordCount;
+const getFallingFactorial = (value: number, count: number): number => {
+  if (value < count) {
+    return 0;
   }
-
-  return total;
-};
-
-const getPatternPermutations = (pattern: readonly JoyfulCategory[]): number => {
-  validateWordCount(pattern.length);
-  validatePattern(pattern);
 
   let total = 1;
 
-  for (const category of pattern) {
-    total *= categoryWordLists[category].length;
+  for (let offset = 0; offset < count; offset += 1) {
+    total *= value - offset;
   }
 
   return total;
 };
 
-const getUniqueWord = (words: string[], maxWordLength?: number): string => {
-  const category = getRandomElement(categories);
-  const pool =
-    maxWordLength === undefined
-      ? category
-      : category.filter((w) => w.length <= maxWordLength);
+const getDefaultPermutations = (
+  segments: number,
+  wordPools: DefaultWordPools = defaultWordLists
+): number => {
+  validateWordCount(segments);
 
-  if (pool.length === 0) {
-    return getUniqueWord(words, maxWordLength);
+  let total = 0;
+  const categoryWordsSet = new Set(wordPools.categoryWords);
+
+  for (const prefix of wordPools.prefixes) {
+    const availableCategoryWords =
+      wordPools.categoryWords.length - (categoryWordsSet.has(prefix) ? 1 : 0);
+    total += getFallingFactorial(availableCategoryWords, segments - 1);
   }
 
-  const word = getRandomElement(pool);
-  return words.includes(word) ? getUniqueWord(words, maxWordLength) : word;
+  return total;
+};
+
+const haveSameWords = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  const words = new Set(a);
+  return b.every((word) => words.has(word));
+};
+
+const arePairwiseDisjoint = (pools: readonly string[][]): boolean => {
+  const seen = new Set<string>();
+
+  for (const pool of pools) {
+    for (const word of pool) {
+      if (seen.has(word)) {
+        return false;
+      }
+
+      seen.add(word);
+    }
+  }
+
+  return true;
+};
+
+const countUniquePatternPermutations = (pools: string[][]): number => {
+  if (pools.some((pool) => pool.length === 0)) {
+    return 0;
+  }
+
+  if (arePairwiseDisjoint(pools)) {
+    return pools.reduce((total, pool) => total * pool.length, 1);
+  }
+
+  if (pools.every((pool) => haveSameWords(pool, pools[0]))) {
+    return getFallingFactorial(pools[0].length, pools.length);
+  }
+
+  const orderedPools = pools.toSorted((a, b) => a.length - b.length);
+
+  const countFrom = (index: number, words: readonly string[]): number => {
+    if (index >= orderedPools.length) {
+      return 1;
+    }
+
+    let total = 0;
+
+    for (const word of orderedPools[index]) {
+      if (!words.includes(word)) {
+        total += countFrom(index + 1, [...words, word]);
+      }
+    }
+
+    return total;
+  };
+
+  return countFrom(0, []);
+};
+
+const getPatternPermutations = (
+  pattern: readonly string[],
+  resolvedOptions: ResolvedOptions = defaultWordLists
+): number => {
+  validateWordCount(pattern.length);
+  validatePattern(
+    resolvedOptions.categoryNames,
+    resolvedOptions.categoryWordLists,
+    pattern
+  );
+
+  const pools = pattern.map((category) =>
+    uniqueWords(resolvedOptions.categoryWordLists[category] ?? [])
+  );
+
+  return countUniquePatternPermutations(pools);
 };
 
 const getUniquePatternWord = (
@@ -203,57 +383,103 @@ const getUniquePatternWord = (
   return candidates.length === 0 ? undefined : getRandomElement(candidates);
 };
 
-const generateUnbounded = (segments: number, separator: string): string => {
-  const words: string[] = [getRandomElement(prefixes)];
+const getUniqueWord = (
+  words: string[],
+  pool: string[],
+  maxWordLength?: number
+): string | undefined => getUniquePatternWord(words, pool, maxWordLength);
 
-  for (let index = 1; index < segments; index += 1) {
-    words.push(getUniqueWord(words));
+const canFillPattern = (
+  pools: string[][],
+  startIndex: number,
+  words: readonly string[],
+  budget?: number
+): boolean => {
+  if (startIndex >= pools.length) {
+    return true;
   }
 
-  return words.join(separator);
-};
+  for (const word of pools[startIndex]) {
+    if (budget !== undefined && word.length > budget) {
+      continue;
+    }
 
-const hasRepeatedCategory = (pattern: readonly JoyfulCategory[]): boolean => {
-  for (let index = 0; index < pattern.length; index += 1) {
-    for (
-      let nextIndex = index + 1;
-      nextIndex < pattern.length;
-      nextIndex += 1
+    if (
+      !words.includes(word) &&
+      canFillPattern(
+        pools,
+        startIndex + 1,
+        [...words, word],
+        budget === undefined ? undefined : budget - word.length
+      )
     ) {
-      if (pattern[index] === pattern[nextIndex]) {
-        return true;
-      }
+      return true;
     }
   }
 
   return false;
 };
 
-const generateDistinctPatternUnbounded = (
-  pattern: readonly JoyfulCategory[],
-  separator: string
-): string => {
-  const words: string[] = [];
+const getViablePatternWord = (
+  pools: string[][],
+  index: number,
+  words: string[],
+  budget?: number
+): string | undefined => {
+  const candidates = pools[index].filter(
+    (word) =>
+      !words.includes(word) &&
+      (budget === undefined || word.length <= budget) &&
+      canFillPattern(
+        pools,
+        index + 1,
+        [...words, word],
+        budget === undefined ? undefined : budget - word.length
+      )
+  );
 
-  for (const category of pattern) {
-    words.push(getRandomElement(categoryWordLists[category]));
+  return candidates.length === 0 ? undefined : getRandomElement(candidates);
+};
+
+const notEnoughWordsError = (): Error =>
+  new Error("Not enough unique words to generate a result");
+
+const generateUnbounded = (
+  segments: number,
+  separator: string,
+  wordPools: DefaultWordPools
+): string => {
+  if (wordPools.prefixes.length === 0) {
+    throw notEnoughWordsError();
+  }
+
+  const words: string[] = [getRandomElement(wordPools.prefixes)];
+
+  for (let index = 1; index < segments; index += 1) {
+    const word = getUniqueWord(words, wordPools.categoryWords);
+
+    if (!word) {
+      throw notEnoughWordsError();
+    }
+
+    words.push(word);
   }
 
   return words.join(separator);
 };
 
 const generatePatternUnbounded = (
-  pattern: readonly JoyfulCategory[],
-  separator: string
+  pattern: readonly string[],
+  separator: string,
+  activeCategoryWordLists: Record<string, string[]>
 ): string => {
-  if (!hasRepeatedCategory(pattern)) {
-    return generateDistinctPatternUnbounded(pattern, separator);
-  }
-
+  const pools = pattern.map(
+    (category) => activeCategoryWordLists[category] ?? []
+  );
   const words: string[] = [];
 
-  for (const category of pattern) {
-    const word = getUniquePatternWord(words, categoryWordLists[category]);
+  for (const [index, category] of pattern.entries()) {
+    const word = getViablePatternWord(pools, index, words);
 
     if (!word) {
       throw new Error(
@@ -276,23 +502,42 @@ const tooShortError = (
     `maxLength ${maxLength} is too short to generate ${segments} segments with separator "${separator}"`
   );
 
+const getMinimumWordLength = (pool: string[]): number => {
+  let minimum = Number.POSITIVE_INFINITY;
+
+  for (const word of pool) {
+    minimum = Math.min(minimum, word.length);
+  }
+
+  return minimum;
+};
+
 const pickBoundedPrefix = (
   budget: number,
-  segments: number
+  segments: number,
+  wordPools: DefaultWordPools
 ): string | undefined => {
-  const maxPrefixLength = budget - (segments - 1) * MIN_CATEGORY_WORD_LENGTH;
-  const filtered = prefixes.filter((w) => w.length <= maxPrefixLength);
+  const minimumCategoryWordLength = getMinimumWordLength(
+    wordPools.categoryWords
+  );
+  const maxPrefixLength = budget - (segments - 1) * minimumCategoryWordLength;
+  const filtered = wordPools.prefixes.filter(
+    (w) => w.length <= maxPrefixLength
+  );
   return filtered.length === 0 ? undefined : getRandomElement(filtered);
 };
 
 const pickBoundedWord = (
   words: string[],
   budget: number,
-  remainingAfter: number
+  remainingAfter: number,
+  wordPools: DefaultWordPools
 ): string | undefined => {
-  const maxWordLength = budget - remainingAfter * MIN_CATEGORY_WORD_LENGTH;
-  const hasValid = categoryWords.some((w) => w.length <= maxWordLength);
-  return hasValid ? getUniqueWord(words, maxWordLength) : undefined;
+  const minimumCategoryWordLength = getMinimumWordLength(
+    wordPools.categoryWords
+  );
+  const maxWordLength = budget - remainingAfter * minimumCategoryWordLength;
+  return getUniqueWord(words, wordPools.categoryWords, maxWordLength);
 };
 
 const fillBoundedWords = (
@@ -300,12 +545,18 @@ const fillBoundedWords = (
   segments: number,
   budget: number,
   maxLength: number,
-  separator: string
+  separator: string,
+  wordPools: DefaultWordPools
 ): number => {
   let remaining = budget;
 
   for (let index = 1; index < segments; index += 1) {
-    const word = pickBoundedWord(words, remaining, segments - index - 1);
+    const word = pickBoundedWord(
+      words,
+      remaining,
+      segments - index - 1,
+      wordPools
+    );
 
     if (!word) {
       throw tooShortError(maxLength, segments, separator);
@@ -316,16 +567,6 @@ const fillBoundedWords = (
   }
 
   return remaining;
-};
-
-const getMinimumWordLength = (pool: string[]): number => {
-  let minimum = Number.POSITIVE_INFINITY;
-
-  for (const word of pool) {
-    minimum = Math.min(minimum, word.length);
-  }
-
-  return minimum;
 };
 
 const getMinimumRemainingLength = (
@@ -344,10 +585,11 @@ const getMinimumRemainingLength = (
 const generateBounded = (
   segments: number,
   separator: string,
-  maxLength: number
+  maxLength: number,
+  wordPools: DefaultWordPools
 ): string => {
   const budget = maxLength - (segments - 1) * separator.length;
-  const prefix = pickBoundedPrefix(budget, segments);
+  const prefix = pickBoundedPrefix(budget, segments, wordPools);
 
   if (!prefix) {
     throw tooShortError(maxLength, segments, separator);
@@ -359,7 +601,8 @@ const generateBounded = (
     segments,
     budget - prefix.length,
     maxLength,
-    separator
+    separator,
+    wordPools
   );
   return words.join(separator);
 };
@@ -373,9 +616,7 @@ const fillPatternBoundedWords = (
 ): void => {
   let remaining = budget;
   for (let index = 0; index < pools.length; index += 1) {
-    const maxWordLength =
-      remaining - getMinimumRemainingLength(pools, index + 1);
-    const word = getUniquePatternWord(words, pools[index], maxWordLength);
+    const word = getViablePatternWord(pools, index, words, remaining);
 
     if (!word) {
       throw tooShortError(maxLength, pools.length, separator);
@@ -387,11 +628,14 @@ const fillPatternBoundedWords = (
 };
 
 const generatePatternBounded = (
-  pattern: readonly JoyfulCategory[],
+  pattern: readonly string[],
   separator: string,
-  maxLength: number
+  maxLength: number,
+  activeCategoryWordLists: Record<string, string[]>
 ): string => {
-  const pools = pattern.map((category) => categoryWordLists[category]);
+  const pools = pattern.map(
+    (category) => activeCategoryWordLists[category] ?? []
+  );
   const budget = maxLength - (pattern.length - 1) * separator.length;
 
   if (budget < getMinimumRemainingLength(pools, 0)) {
@@ -404,31 +648,49 @@ const generatePatternBounded = (
 };
 
 export const joyful = (options: JoyfulOptions = {}): string => {
-  const { maxLength, pattern, segments = 2, separator = "-" } = options;
+  const {
+    maxLength,
+    omit = [],
+    pattern,
+    segments = 2,
+    separator = "-",
+    wordLists,
+  } = options;
+  const resolvedOptions = getActiveWordLists(wordLists, omit);
 
-  validateInput(segments, separator, maxLength, pattern);
+  validateInput(segments, separator, maxLength, pattern, resolvedOptions);
 
   if (pattern) {
     if (maxLength === undefined) {
-      return generatePatternUnbounded(pattern, separator);
+      return generatePatternUnbounded(
+        pattern,
+        separator,
+        resolvedOptions.categoryWordLists
+      );
     }
 
-    return generatePatternBounded(pattern, separator, maxLength);
+    return generatePatternBounded(
+      pattern,
+      separator,
+      maxLength,
+      resolvedOptions.categoryWordLists
+    );
   }
 
   if (maxLength === undefined) {
-    return generateUnbounded(segments, separator);
+    return generateUnbounded(segments, separator, resolvedOptions);
   }
 
-  return generateBounded(segments, separator, maxLength);
+  return generateBounded(segments, separator, maxLength, resolvedOptions);
 };
 
 export const permutations = (options: PermutationsOptions = {}): number => {
-  const { pattern, segments = 2 } = options;
+  const { omit = [], pattern, segments = 2, wordLists } = options;
+  const resolvedOptions = getActiveWordLists(wordLists, omit);
 
   if (pattern) {
-    return getPatternPermutations(pattern);
+    return getPatternPermutations(pattern, resolvedOptions);
   }
 
-  return getDefaultPermutations(segments);
+  return getDefaultPermutations(segments, resolvedOptions);
 };


### PR DESCRIPTION
## Summary

- add custom word lists through `wordLists` and CLI `--word-list` flags
- add exact-word omissions through `omit` and CLI `--omit` flags
- update permutation counts to reflect unique generatable names, including overlapping custom lists
- remove GitHub sponsorship funding metadata

## Validation

- `bun test`
- `bun run check`

## Notes

- includes a minor changeset for the new API and CLI behavior
